### PR TITLE
Add contractUri parameter to createCollection

### DIFF
--- a/app/api/in_process/createCollection.ts
+++ b/app/api/in_process/createCollection.ts
@@ -4,7 +4,12 @@ import { CdpClient } from "@coinbase/cdp-sdk";
 import { encodeFunctionData } from "viem";
 
 // Main function to create a collection
-async function createCollection(collectionName: string) {
+interface CreateCollectionParams {
+  collectionName: string;
+  uri: string;
+}
+
+async function createCollection({ collectionName, uri }: CreateCollectionParams) {
   // Initialize CDP client with your credentials
   const cdp = new CdpClient({
     apiKeyId: process.env.CDP_API_KEY_ID,
@@ -20,9 +25,6 @@ async function createCollection(collectionName: string) {
     owner: evmAccount,
   });
 
-  // Collection details
-  const contractUri = "ar://contractUri"; // Your contract metadata URI
-
   // Royalty configuration
   const royaltyConfig = {
     royaltyMintSchedule: 0,
@@ -35,7 +37,7 @@ async function createCollection(collectionName: string) {
     abi: inProcessProtocolAbi,
     functionName: "createContract",
     args: [
-      contractUri,
+      uri,
       collectionName,
       royaltyConfig,
       smartAccount.address, // defaultAdmin

--- a/lib/imageGeneration.ts
+++ b/lib/imageGeneration.ts
@@ -68,7 +68,10 @@ export async function generateAndProcessImage(
   }
 
   // Create a collection on the blockchain
-  const result = await createCollection(prompt);
+  const result = await createCollection({
+    collectionName: prompt,
+    uri: arweaveData?.url ?? "",
+  });
   const transactionHash = result.transactionHash || null;
 
   // Return complete response

--- a/lib/txtGeneration.ts
+++ b/lib/txtGeneration.ts
@@ -47,7 +47,10 @@ export async function generateAndStoreTxtFile(
   }
 
   // Create a collection on the blockchain
-  const result = await createCollection(contents);
+  const result = await createCollection({
+    collectionName: contents,
+    uri: arweaveData?.url ?? "",
+  });
   const transactionHash = result.transactionHash || null;
 
   return {


### PR DESCRIPTION
## Summary
- make `createCollection` accept an object with `collectionName` and `uri`
- pass the object to `createCollection` in image and text generation

## Testing
- `pnpm lint` *(fails: next not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced collection creation to support both a collection name and an associated URI, allowing for more flexible and descriptive collections.

- **Refactor**
  - Updated internal handling of collection creation to accept additional parameters, improving future extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->