### PR TITLE
Use ar:// prefix for arweave IDs

### DIFF
--- a/lib/imageGeneration.ts
+++ b/lib/imageGeneration.ts
@@ -67,10 +67,10 @@ export async function generateAndProcessImage(
     // We'll continue and return the image even if Arweave upload fails
   }
 
-  // Create a collection on the blockchain
+  // Create a collection on the blockchain using the Arweave id
   const result = await createCollection({
     collectionName: prompt,
-    uri: arweaveData?.url ?? "",
+    uri: arweaveData ? `ar://${arweaveData.id}` : "",
   });
   const transactionHash = result.transactionHash || null;
 

--- a/lib/txtGeneration.ts
+++ b/lib/txtGeneration.ts
@@ -46,10 +46,10 @@ export async function generateAndStoreTxtFile(
     // Continue and return the TXT even if Arweave upload fails
   }
 
-  // Create a collection on the blockchain
+  // Create a collection on the blockchain using the Arweave id
   const result = await createCollection({
     collectionName: contents,
-    uri: arweaveData?.url ?? "",
+    uri: arweaveData ? `ar://${arweaveData.id}` : "",
   });
   const transactionHash = result.transactionHash || null;
 


### PR DESCRIPTION
## Summary
- prefix the collection URI with `ar://` for generated images
- prefix the collection URI with `ar://` for generated text

## Testing
- `pnpm lint` *(fails: next not found / missing node modules)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated how Arweave resources are referenced when creating blockchain collections, switching from full URLs to protocol-prefixed IDs for improved consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->