### PR TITLE
Use metadata helper for Arweave uploads

### DIFF
--- a/lib/arweave/uploadMetadataJson.ts
+++ b/lib/arweave/uploadMetadataJson.ts
@@ -1,0 +1,40 @@
+import { uploadBase64ToArweave } from "./uploadBase64ToArweave";
+
+export interface MetadataUploadResult {
+  id: string;
+  url: string;
+}
+
+interface UploadMetadataParams {
+  name: string;
+  imageId?: string;
+}
+
+/**
+ * Upload collection metadata JSON to Arweave. The metadata includes the
+ * collection name and optional image reference using the `ar://` protocol.
+ */
+export async function uploadMetadataJson({
+  name,
+  imageId,
+}: UploadMetadataParams): Promise<MetadataUploadResult> {
+  const metadata = {
+    image: imageId ? `ar://${imageId}` : "",
+    name,
+  };
+
+  const metadataBase64 = Buffer.from(JSON.stringify(metadata)).toString(
+    "base64",
+  );
+
+  const result = await uploadBase64ToArweave(
+    metadataBase64,
+    "application/json",
+    `metadata-${Date.now()}.json`,
+  );
+
+  return {
+    id: result.id,
+    url: result.url,
+  };
+}


### PR DESCRIPTION
## Summary
- add shared helper `uploadMetadataJson`
- upload collection metadata via shared helper
- include metadata info inside `arweave` field in generation results

## Testing
- `pnpm lint` *(fails: `next` not found)*