### PR TITLE
Use metadata JSON for collection URI

### DIFF
--- a/lib/arweave/uploadMetadataJson.ts
+++ b/lib/arweave/uploadMetadataJson.ts
@@ -1,7 +1,10 @@
-import { uploadBase64ToArweave } from "./uploadBase64ToArweave";
+import {
+  ArweaveUploadResult,
+  uploadBase64ToArweave,
+} from "./uploadBase64ToArweave";
 
 interface CreateMetadataArgs {
-  arweaveData?: { id: string } | null;
+  arweaveData?: ArweaveUploadResult;
   name: string;
 }
 

--- a/lib/arweave/uploadMetadataJson.ts
+++ b/lib/arweave/uploadMetadataJson.ts
@@ -1,0 +1,30 @@
+import { uploadBase64ToArweave } from "./uploadBase64ToArweave";
+
+interface CreateMetadataArgs {
+  arweaveData?: { id: string } | null;
+  prompt: string;
+}
+
+/**
+ * Uploads a metadata JSON object to Arweave as a base64-encoded file.
+ * @param args The metadata creation arguments
+ * @returns The result from uploadBase64ToArweave
+ */
+export async function uploadMetadataJson({
+  arweaveData,
+  prompt,
+}: CreateMetadataArgs) {
+  const metadata = {
+    image: arweaveData ? `ar://${arweaveData.id}` : "",
+    name: prompt,
+  };
+  const metadataBase64 = Buffer.from(JSON.stringify(metadata)).toString(
+    "base64"
+  );
+  const metadataResult = await uploadBase64ToArweave(
+    metadataBase64,
+    "application/json",
+    `metadata-${Date.now()}.json`
+  );
+  return metadataResult;
+}

--- a/lib/arweave/uploadMetadataJson.ts
+++ b/lib/arweave/uploadMetadataJson.ts
@@ -4,7 +4,7 @@ import {
 } from "./uploadBase64ToArweave";
 
 interface CreateMetadataArgs {
-  arweaveData?: ArweaveUploadResult;
+  arweaveData?: ArweaveUploadResult | null;
   name: string;
 }
 

--- a/lib/arweave/uploadMetadataJson.ts
+++ b/lib/arweave/uploadMetadataJson.ts
@@ -2,7 +2,7 @@ import { uploadBase64ToArweave } from "./uploadBase64ToArweave";
 
 interface CreateMetadataArgs {
   arweaveData?: { id: string } | null;
-  prompt: string;
+  name: string;
 }
 
 /**
@@ -12,11 +12,11 @@ interface CreateMetadataArgs {
  */
 export async function uploadMetadataJson({
   arweaveData,
-  prompt,
+  name,
 }: CreateMetadataArgs) {
   const metadata = {
     image: arweaveData ? `ar://${arweaveData.id}` : "",
-    name: prompt,
+    name,
   };
   const metadataBase64 = Buffer.from(JSON.stringify(metadata)).toString(
     "base64"

--- a/lib/imageGeneration.ts
+++ b/lib/imageGeneration.ts
@@ -1,6 +1,9 @@
 import { experimental_generateImage as generateImage } from "ai";
 import { openai } from "@ai-sdk/openai";
-import { uploadBase64ToArweave } from "@/lib/arweave/uploadBase64ToArweave";
+import {
+  ArweaveUploadResult,
+  uploadBase64ToArweave,
+} from "@/lib/arweave/uploadBase64ToArweave";
 import createCollection from "@/app/api/in_process/createCollection";
 import { uploadMetadataJson } from "./arweave/uploadMetadataJson";
 
@@ -9,10 +12,7 @@ export interface GeneratedImageResponse {
     base64Data: string;
     mimeType: string;
   };
-  arweave?: {
-    id: string;
-    url: string;
-  } | null;
+  arweave?: ArweaveUploadResult | null;
   smartAccount: {
     address: string;
     [key: string]: unknown;

--- a/lib/imageGeneration.ts
+++ b/lib/imageGeneration.ts
@@ -69,7 +69,7 @@ export async function generateAndProcessImage(
   try {
     metadataArweave = await uploadMetadataJson({
       arweaveData,
-      prompt,
+      name: prompt,
     });
   } catch (metadataError) {
     console.error("Error uploading metadata to Arweave:", metadataError);

--- a/lib/txtGeneration.ts
+++ b/lib/txtGeneration.ts
@@ -45,7 +45,7 @@ export async function generateAndStoreTxtFile(
   try {
     metadataArweave = await uploadMetadataJson({
       arweaveData,
-      prompt: contents,
+      name: contents,
     });
   } catch (metadataError) {
     console.error("Error uploading metadata to Arweave:", metadataError);

--- a/lib/txtGeneration.ts
+++ b/lib/txtGeneration.ts
@@ -1,6 +1,8 @@
-import { uploadBase64ToArweave } from "@/lib/arweave/uploadBase64ToArweave";
+import {
+  ArweaveUploadResult,
+  uploadBase64ToArweave,
+} from "@/lib/arweave/uploadBase64ToArweave";
 import createCollection from "@/app/api/in_process/createCollection";
-import { IS_PROD } from "./consts";
 import { uploadMetadataJson } from "./arweave/uploadMetadataJson";
 
 export interface GeneratedTxtResponse {
@@ -8,10 +10,7 @@ export interface GeneratedTxtResponse {
     base64Data: string;
     mimeType: string;
   };
-  arweave?: {
-    id: string;
-    url: string;
-  } | null;
+  arweave?: ArweaveUploadResult | null;
   smartAccount: {
     address: string;
     [key: string]: unknown;


### PR DESCRIPTION
## Summary
- generate Arweave metadata JSON for image collections
- generate Arweave metadata JSON for text collections
- remove `metadataArweave` from the returned objects

## Testing
- `pnpm lint` *(fails: `next` not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Metadata for generated images and text files is now uploaded to Arweave, providing an additional Arweave link in the response.
- **Bug Fixes**
  - Improved error handling ensures that issues during metadata upload do not interrupt the overall process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->