### PR TITLE
Add setup action helper and ABI const

### DIFF
--- a/abi/inProcessImplementationAbi.ts
+++ b/abi/inProcessImplementationAbi.ts
@@ -1,0 +1,20 @@
+export const inProcessImplementationAbi = [
+  {
+    inputs: [
+      {
+        internalType: "string",
+        name: "uri",
+        type: "string",
+      },
+      {
+        internalType: "uint256",
+        name: "maxSupply",
+        type: "uint256",
+      },
+    ],
+    name: "setupNewToken",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;

--- a/abi/inProcessImplementationAbi.ts
+++ b/abi/inProcessImplementationAbi.ts
@@ -2,8 +2,2190 @@ export const inProcessImplementationAbi = [
   {
     inputs: [
       {
+        internalType: "address",
+        name: "_mintFeeRecipient",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "_upgradeGate",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "_protocolRewards",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "_timedSaleStrategy",
+        type: "address",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    inputs: [],
+    name: "ADDRESS_DELEGATECALL_TO_NON_CONTRACT",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ADDRESS_LOW_LEVEL_CALL_FAILED",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "operator",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+    ],
+    name: "Burn_NotOwnerOrApproved",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "CREATOR_FUNDS_RECIPIENT_NOT_SET",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes",
+        name: "reason",
+        type: "bytes",
+      },
+    ],
+    name: "CallFailed",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "Call_TokenIdMismatch",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "CallerNotZoraCreator1155",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "CanOnlyReduceMaxSupply",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "quantity",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "totalMinted",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "maxSupply",
+        type: "uint256",
+      },
+    ],
+    name: "CannotMintMoreTokens",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "CannotReduceMaxSupplyBelowMinted",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "proposedAddress",
+        type: "address",
+      },
+    ],
+    name: "Config_TransferHookNotSupported",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1155_ACCOUNTS_AND_IDS_LENGTH_MISMATCH",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1155_ADDRESS_ZERO_IS_NOT_A_VALID_OWNER",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1155_BURN_AMOUNT_EXCEEDS_BALANCE",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1155_BURN_FROM_ZERO_ADDRESS",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1155_CALLER_IS_NOT_TOKEN_OWNER_OR_APPROVED",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1155_ERC1155RECEIVER_REJECTED_TOKENS",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1155_IDS_AND_AMOUNTS_LENGTH_MISMATCH",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1155_INSUFFICIENT_BALANCE_FOR_TRANSFER",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1155_MINT_TO_ZERO_ADDRESS",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1155_MINT_TO_ZERO_ADDRESS",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1155_SETTING_APPROVAL_FOR_SELF",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1155_TRANSFER_TO_NON_ERC1155RECEIVER_IMPLEMENTER",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1155_TRANSFER_TO_ZERO_ADDRESS",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1967_NEW_IMPL_NOT_CONTRACT",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1967_NEW_IMPL_NOT_UUPS",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ERC1967_UNSUPPORTED_PROXIABLEUUID",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "ETHWithdrawFailed",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "FUNCTION_MUST_BE_CALLED_THROUGH_ACTIVE_PROXY",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "FUNCTION_MUST_BE_CALLED_THROUGH_DELEGATECALL",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "FirstMinterAddressZero",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "contractValue",
+        type: "uint256",
+      },
+    ],
+    name: "FundsWithdrawInsolvent",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "INITIALIZABLE_CONTRACT_ALREADY_INITIALIZED",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "INITIALIZABLE_CONTRACT_IS_NOT_INITIALIZING",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "INVALID_ADDRESS_ZERO",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "INVALID_ETH_AMOUNT",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "mintTo",
+        type: "address",
+      },
+      {
+        internalType: "bytes32[]",
+        name: "merkleProof",
+        type: "bytes32[]",
+      },
+      {
+        internalType: "bytes32",
+        name: "merkleRoot",
+        type: "bytes32",
+      },
+    ],
+    name: "InvalidMerkleProof",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidMintSchedule",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidMintSchedule",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidPremintVersion",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidSignature",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidSignatureVersion",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes4",
+        name: "magicValue",
+        type: "bytes4",
+      },
+    ],
+    name: "InvalidSigner",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "MintNotYetStarted",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "Mint_InsolventSaleTransfer",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "Mint_InvalidMintArrayLength",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "Mint_TokenIDMintNotAllowed",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "Mint_UnknownCommand",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "Mint_ValueTransferFail",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "MinterContractAlreadyExists",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "MinterContractDoesNotExist",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "NewOwnerNeedsToBeAdmin",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+    ],
+    name: "NoRendererForToken",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "NonEthRedemption",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ONLY_CREATE_REFERRAL",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "OnlyAllowedForRegisteredMinter",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "OnlyAllowedForTimedSaleStrategy",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "OnlyTransfersFromZoraMints",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "PremintDeleted",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "caller",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "ProtocolRewardsWithdrawFailed",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "renderer",
+        type: "address",
+      },
+    ],
+    name: "RendererNotValid",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "Renderer_NotValidRendererContract",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "SaleEnded",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "SaleHasNotStarted",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "targetContract",
+        type: "address",
+      },
+    ],
+    name: "Sale_CannotCallNonSalesContract",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "expected",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "actual",
+        type: "uint256",
+      },
+    ],
+    name: "TokenIdMismatch",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "UUPS_UPGRADEABLE_MUST_NOT_BE_CALLED_THROUGH_DELEGATECALL",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "limit",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "requestedAmount",
+        type: "uint256",
+      },
+    ],
+    name: "UserExceedsMintLimit",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "role",
+        type: "uint256",
+      },
+    ],
+    name: "UserMissingRoleForToken",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "WrongValueSent",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "premintSignerContractFailedToRecoverSigner",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "premintSignerContractNotAContract",
+    type: "error",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "previousAdmin",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "newAdmin",
+        type: "address",
+      },
+    ],
+    name: "AdminChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "operator",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "approved",
+        type: "bool",
+      },
+    ],
+    name: "ApprovalForAll",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "beacon",
+        type: "address",
+      },
+    ],
+    name: "BeaconUpgraded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "updater",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "enum IZoraCreator1155.ConfigUpdate",
+        name: "updateType",
+        type: "uint8",
+      },
+      {
+        components: [
+          {
+            internalType: "address",
+            name: "owner",
+            type: "address",
+          },
+          {
+            internalType: "uint96",
+            name: "__gap1",
+            type: "uint96",
+          },
+          {
+            internalType: "address payable",
+            name: "fundsRecipient",
+            type: "address",
+          },
+          {
+            internalType: "uint96",
+            name: "__gap2",
+            type: "uint96",
+          },
+          {
+            internalType: "contract ITransferHookReceiver",
+            name: "transferHook",
+            type: "address",
+          },
+          {
+            internalType: "uint96",
+            name: "__gap3",
+            type: "uint96",
+          },
+        ],
+        indexed: false,
+        internalType: "struct IZoraCreator1155TypesV1.ContractConfig",
+        name: "newConfig",
+        type: "tuple",
+      },
+    ],
+    name: "ConfigUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "updater",
+        type: "address",
+      },
+      {
+        indexed: false,
         internalType: "string",
         name: "uri",
+        type: "string",
+      },
+      {
+        indexed: false,
+        internalType: "string",
+        name: "name",
+        type: "string",
+      },
+    ],
+    name: "ContractMetadataUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "contract IRenderer1155",
+        name: "renderer",
+        type: "address",
+      },
+    ],
+    name: "ContractRendererUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [],
+    name: "ContractURIUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "structHash",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "string",
+        name: "domainName",
+        type: "string",
+      },
+      {
+        indexed: false,
+        internalType: "string",
+        name: "version",
+        type: "string",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "creator",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bytes",
+        name: "signature",
+        type: "bytes",
+      },
+    ],
+    name: "CreatorAttribution",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint8",
+        name: "version",
+        type: "uint8",
+      },
+    ],
+    name: "Initialized",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "lastOwner",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "newOwner",
+        type: "address",
+      },
+    ],
+    name: "OwnershipTransferred",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "minter",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "quantity",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+    ],
+    name: "Purchased",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "renderer",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+    ],
+    name: "RendererUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "string",
+        name: "newURI",
+        type: "string",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "maxSupply",
+        type: "uint256",
+      },
+    ],
+    name: "SetupNewToken",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "operator",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256[]",
+        name: "ids",
+        type: "uint256[]",
+      },
+      {
+        indexed: false,
+        internalType: "uint256[]",
+        name: "values",
+        type: "uint256[]",
+      },
+    ],
+    name: "TransferBatch",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "operator",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "id",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+    ],
+    name: "TransferSingle",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "string",
+        name: "value",
+        type: "string",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "id",
+        type: "uint256",
+      },
+    ],
+    name: "URI",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "permissions",
+        type: "uint256",
+      },
+    ],
+    name: "UpdatedPermissions",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        components: [
+          {
+            internalType: "uint32",
+            name: "royaltyMintSchedule",
+            type: "uint32",
+          },
+          {
+            internalType: "uint32",
+            name: "royaltyBPS",
+            type: "uint32",
+          },
+          {
+            internalType: "address",
+            name: "royaltyRecipient",
+            type: "address",
+          },
+        ],
+        indexed: false,
+        internalType: "struct ICreatorRoyaltiesControl.RoyaltyConfiguration",
+        name: "configuration",
+        type: "tuple",
+      },
+    ],
+    name: "UpdatedRoyalties",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        components: [
+          {
+            internalType: "string",
+            name: "uri",
+            type: "string",
+          },
+          {
+            internalType: "uint256",
+            name: "maxSupply",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "totalMinted",
+            type: "uint256",
+          },
+        ],
+        indexed: false,
+        internalType: "struct IZoraCreator1155TypesV1.TokenData",
+        name: "tokenData",
+        type: "tuple",
+      },
+    ],
+    name: "UpdatedToken",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "implementation",
+        type: "address",
+      },
+    ],
+    name: "Upgraded",
+    type: "event",
+  },
+  {
+    inputs: [],
+    name: "CONTRACT_BASE_ID",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "PERMISSION_BIT_ADMIN",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "PERMISSION_BIT_FUNDS_MANAGER",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "PERMISSION_BIT_METADATA",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "PERMISSION_BIT_MINTER",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "PERMISSION_BIT_SALES",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "permissionBits",
+        type: "uint256",
+      },
+    ],
+    name: "addPermission",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "quantity",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "data",
+        type: "bytes",
+      },
+    ],
+    name: "adminMint",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "lastTokenId",
+        type: "uint256",
+      },
+    ],
+    name: "assumeLastTokenIdMatches",
+    outputs: [],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "id",
+        type: "uint256",
+      },
+    ],
+    name: "balanceOf",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address[]",
+        name: "accounts",
+        type: "address[]",
+      },
+      {
+        internalType: "uint256[]",
+        name: "ids",
+        type: "uint256[]",
+      },
+    ],
+    name: "balanceOfBatch",
+    outputs: [
+      {
+        internalType: "uint256[]",
+        name: "batchBalances",
+        type: "uint256[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "uint256[]",
+        name: "tokenIds",
+        type: "uint256[]",
+      },
+      {
+        internalType: "uint256[]",
+        name: "amounts",
+        type: "uint256[]",
+      },
+    ],
+    name: "burnBatch",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "data",
+        type: "bytes",
+      },
+    ],
+    name: "callRenderer",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "contract IMinter1155",
+        name: "salesConfig",
+        type: "address",
+      },
+      {
+        internalType: "bytes",
+        name: "data",
+        type: "bytes",
+      },
+    ],
+    name: "callSale",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "mintPrice",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "quantity",
+        type: "uint256",
+      },
+    ],
+    name: "computeTotalReward",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "pure",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "config",
+    outputs: [
+      {
+        internalType: "address",
+        name: "owner",
+        type: "address",
+      },
+      {
+        internalType: "uint96",
+        name: "__gap1",
+        type: "uint96",
+      },
+      {
+        internalType: "address payable",
+        name: "fundsRecipient",
+        type: "address",
+      },
+      {
+        internalType: "uint96",
+        name: "__gap2",
+        type: "uint96",
+      },
+      {
+        internalType: "contract ITransferHookReceiver",
+        name: "transferHook",
+        type: "address",
+      },
+      {
+        internalType: "uint96",
+        name: "__gap3",
+        type: "uint96",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "contractName",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "contractURI",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "contractVersion",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "pure",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    name: "createReferrals",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    name: "customRenderers",
+    outputs: [
+      {
+        internalType: "contract IRenderer1155",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes",
+        name: "premintConfig",
+        type: "bytes",
+      },
+      {
+        internalType: "bytes32",
+        name: "premintVersion",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes",
+        name: "signature",
+        type: "bytes",
+      },
+      {
+        internalType: "address",
+        name: "firstMinter",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "premintSignerContract",
+        type: "address",
+      },
+    ],
+    name: "delegateSetupNewToken",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "newTokenId",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint32",
+        name: "",
+        type: "uint32",
+      },
+    ],
+    name: "delegatedTokenId",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    name: "firstMinters",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+    ],
+    name: "getCreatorRewardRecipient",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+    ],
+    name: "getCustomRenderer",
+    outputs: [
+      {
+        internalType: "contract IRenderer1155",
+        name: "customRenderer",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+    ],
+    name: "getRoyalties",
+    outputs: [
+      {
+        components: [
+          {
+            internalType: "uint32",
+            name: "royaltyMintSchedule",
+            type: "uint32",
+          },
+          {
+            internalType: "uint32",
+            name: "royaltyBPS",
+            type: "uint32",
+          },
+          {
+            internalType: "address",
+            name: "royaltyRecipient",
+            type: "address",
+          },
+        ],
+        internalType: "struct ICreatorRoyaltiesControl.RoyaltyConfiguration",
+        name: "",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+    ],
+    name: "getTokenInfo",
+    outputs: [
+      {
+        components: [
+          {
+            internalType: "string",
+            name: "uri",
+            type: "string",
+          },
+          {
+            internalType: "uint256",
+            name: "maxSupply",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "totalMinted",
+            type: "uint256",
+          },
+        ],
+        internalType: "struct IZoraCreator1155TypesV1.TokenData",
+        name: "",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "implementation",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "string",
+        name: "contractName",
+        type: "string",
+      },
+      {
+        internalType: "string",
+        name: "newContractURI",
+        type: "string",
+      },
+      {
+        components: [
+          {
+            internalType: "uint32",
+            name: "royaltyMintSchedule",
+            type: "uint32",
+          },
+          {
+            internalType: "uint32",
+            name: "royaltyBPS",
+            type: "uint32",
+          },
+          {
+            internalType: "address",
+            name: "royaltyRecipient",
+            type: "address",
+          },
+        ],
+        internalType: "struct ICreatorRoyaltiesControl.RoyaltyConfiguration",
+        name: "defaultRoyaltyConfiguration",
+        type: "tuple",
+      },
+      {
+        internalType: "address payable",
+        name: "defaultAdmin",
+        type: "address",
+      },
+      {
+        internalType: "bytes[]",
+        name: "setupActions",
+        type: "bytes[]",
+      },
+    ],
+    name: "initialize",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "role",
+        type: "uint256",
+      },
+    ],
+    name: "isAdminOrRole",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "operator",
+        type: "address",
+      },
+    ],
+    name: "isApprovedForAll",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    name: "metadataRendererContract",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "contract IMinter1155",
+        name: "minter",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "quantity",
+        type: "uint256",
+      },
+      {
+        internalType: "address[]",
+        name: "rewardsRecipients",
+        type: "address[]",
+      },
+      {
+        internalType: "bytes",
+        name: "minterArguments",
+        type: "bytes",
+      },
+    ],
+    name: "mint",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "mintFee",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes[]",
+        name: "data",
+        type: "bytes[]",
+      },
+    ],
+    name: "multicall",
+    outputs: [
+      {
+        internalType: "bytes[]",
+        name: "results",
+        type: "bytes[]",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "name",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "nextTokenId",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "owner",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    name: "permissions",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "proxiableUUID",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "newMaxSupply",
+        type: "uint256",
+      },
+    ],
+    name: "reduceSupply",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "permissionBits",
+        type: "uint256",
+      },
+    ],
+    name: "removePermission",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    name: "royalties",
+    outputs: [
+      {
+        internalType: "uint32",
+        name: "royaltyMintSchedule",
+        type: "uint32",
+      },
+      {
+        internalType: "uint32",
+        name: "royaltyBPS",
+        type: "uint32",
+      },
+      {
+        internalType: "address",
+        name: "royaltyRecipient",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "salePrice",
+        type: "uint256",
+      },
+    ],
+    name: "royaltyInfo",
+    outputs: [
+      {
+        internalType: "address",
+        name: "receiver",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "royaltyAmount",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256[]",
+        name: "ids",
+        type: "uint256[]",
+      },
+      {
+        internalType: "uint256[]",
+        name: "amounts",
+        type: "uint256[]",
+      },
+      {
+        internalType: "bytes",
+        name: "data",
+        type: "bytes",
+      },
+    ],
+    name: "safeBatchTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "id",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "data",
+        type: "bytes",
+      },
+    ],
+    name: "safeTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "operator",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "approved",
+        type: "bool",
+      },
+    ],
+    name: "setApprovalForAll",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address payable",
+        name: "fundsRecipient",
+        type: "address",
+      },
+    ],
+    name: "setFundsRecipient",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "newOwner",
+        type: "address",
+      },
+    ],
+    name: "setOwner",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "contract IRenderer1155",
+        name: "renderer",
+        type: "address",
+      },
+    ],
+    name: "setTokenMetadataRenderer",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "contract ITransferHookReceiver",
+        name: "transferHook",
+        type: "address",
+      },
+    ],
+    name: "setTransferHook",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "string",
+        name: "newURI",
         type: "string",
       },
       {
@@ -13,8 +2195,238 @@ export const inProcessImplementationAbi = [
       },
     ],
     name: "setupNewToken",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "string",
+        name: "newURI",
+        type: "string",
+      },
+      {
+        internalType: "uint256",
+        name: "maxSupply",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "createReferral",
+        type: "address",
+      },
+    ],
+    name: "setupNewTokenWithCreateReferral",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "supportedPremintSignatureVersions",
+    outputs: [
+      {
+        internalType: "string[]",
+        name: "",
+        type: "string[]",
+      },
+    ],
+    stateMutability: "pure",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes4",
+        name: "interfaceId",
+        type: "bytes4",
+      },
+    ],
+    name: "supportsInterface",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "symbol",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "pure",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "string",
+        name: "_newURI",
+        type: "string",
+      },
+      {
+        internalType: "string",
+        name: "_newName",
+        type: "string",
+      },
+    ],
+    name: "updateContractMetadata",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+    ],
+    name: "updateCreateReferral",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        components: [
+          {
+            internalType: "uint32",
+            name: "royaltyMintSchedule",
+            type: "uint32",
+          },
+          {
+            internalType: "uint32",
+            name: "royaltyBPS",
+            type: "uint32",
+          },
+          {
+            internalType: "address",
+            name: "royaltyRecipient",
+            type: "address",
+          },
+        ],
+        internalType: "struct ICreatorRoyaltiesControl.RoyaltyConfiguration",
+        name: "newConfiguration",
+        type: "tuple",
+      },
+    ],
+    name: "updateRoyaltiesForToken",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        internalType: "string",
+        name: "_newURI",
+        type: "string",
+      },
+    ],
+    name: "updateTokenURI",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "newImplementation",
+        type: "address",
+      },
+    ],
+    name: "upgradeTo",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "newImplementation",
+        type: "address",
+      },
+      {
+        internalType: "bytes",
+        name: "data",
+        type: "bytes",
+      },
+    ],
+    name: "upgradeToAndCall",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+    ],
+    name: "uri",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "withdraw",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    stateMutability: "payable",
+    type: "receive",
   },
 ] as const;

--- a/app/api/in_process/createCollection.ts
+++ b/app/api/in_process/createCollection.ts
@@ -14,7 +14,10 @@ interface CreateCollectionParams {
   uri: string;
 }
 
-async function createCollection({ collectionName, uri }: CreateCollectionParams) {
+async function createCollection({
+  collectionName,
+  uri,
+}: CreateCollectionParams) {
   // Initialize CDP client with your credentials
   const cdp = new CdpClient({
     apiKeyId: process.env.CDP_API_KEY_ID,
@@ -46,7 +49,7 @@ async function createCollection({ collectionName, uri }: CreateCollectionParams)
       collectionName,
       royaltyConfig,
       smartAccount.address, // defaultAdmin
-      [getSetupNewTokenCall(uri, 0n)], // setupActions
+      [getSetupNewTokenCall(uri, BigInt(0))], // setupActions
     ],
   });
 

--- a/app/api/in_process/createCollection.ts
+++ b/app/api/in_process/createCollection.ts
@@ -1,4 +1,5 @@
 import { inProcessProtocolAbi } from "@/abi/inProcessProtocolAbi";
+import { getSetupNewTokenCall } from "@/app/lib/in_process/getSetupNewTokenCall";
 import {
   IN_PROCESS_PROTOCOL_ADDRESS,
   IS_PROD,
@@ -45,7 +46,7 @@ async function createCollection({ collectionName, uri }: CreateCollectionParams)
       collectionName,
       royaltyConfig,
       smartAccount.address, // defaultAdmin
-      [], // setupActions
+      [getSetupNewTokenCall(uri, 0n)], // setupActions
     ],
   });
 

--- a/app/api/in_process/createCollection.ts
+++ b/app/api/in_process/createCollection.ts
@@ -36,9 +36,11 @@ async function createCollection({
   // Royalty configuration
   const royaltyConfig = {
     royaltyMintSchedule: 0,
-    royaltyBPS: 0, // 0% royalties (set to 1000 for 10%)
+    royaltyBPS: 500, // 5% royalties (set to 1000 for 10%)
     royaltyRecipient: smartAccount.address,
   };
+
+  const setupActions = [getSetupNewTokenCall({ uri })];
 
   // Encode the function call data
   const createContractData = encodeFunctionData({
@@ -49,7 +51,7 @@ async function createCollection({
       collectionName,
       royaltyConfig,
       smartAccount.address, // defaultAdmin
-      [getSetupNewTokenCall(uri, BigInt(0))], // setupActions
+      setupActions,
     ],
   });
 

--- a/app/lib/in_process/getSetupNewTokenCall.ts
+++ b/app/lib/in_process/getSetupNewTokenCall.ts
@@ -1,7 +1,13 @@
 import { inProcessImplementationAbi } from "@/abi/inProcessImplementationAbi";
-import { encodeFunctionData } from "viem";
+import { encodeFunctionData, maxUint256 } from "viem";
 
-export const getSetupNewTokenCall = (uri: string, maxSupply: bigint) =>
+export const getSetupNewTokenCall = ({
+  uri = "ar://",
+  maxSupply = maxUint256,
+}: {
+  uri?: string;
+  maxSupply?: bigint;
+}) =>
   encodeFunctionData({
     abi: inProcessImplementationAbi,
     functionName: "setupNewToken",

--- a/app/lib/in_process/getSetupNewTokenCall.ts
+++ b/app/lib/in_process/getSetupNewTokenCall.ts
@@ -1,0 +1,9 @@
+import { inProcessImplementationAbi } from "@/abi/inProcessImplementationAbi";
+import { encodeFunctionData } from "viem";
+
+export const getSetupNewTokenCall = (uri: string, maxSupply: bigint) =>
+  encodeFunctionData({
+    abi: inProcessImplementationAbi,
+    functionName: "setupNewToken",
+    args: [uri, maxSupply],
+  });

--- a/lib/ai/generateImage.ts
+++ b/lib/ai/generateImage.ts
@@ -1,0 +1,43 @@
+import { experimental_generateImage as generate } from "ai";
+import { openai } from "@ai-sdk/openai";
+import {
+  ArweaveUploadResult,
+  uploadBase64ToArweave,
+} from "../arweave/uploadBase64ToArweave";
+
+const generateImage = async (
+  prompt: string
+): Promise<ArweaveUploadResult | null> => {
+  const response = await generate({
+    model: openai.image("gpt-image-1"),
+    prompt,
+    providerOptions: {
+      openai: { quality: "high" },
+    },
+  });
+
+  // The base64Data isn't properly typed in the ai SDK, so we need to cast the response
+  // @ts-expect-error The 'image' object from generateImage includes base64Data but it's not in the type
+  const base64Data: string = response.image.base64Data;
+
+  const imageData = {
+    base64Data,
+    mimeType: response.image.mimeType,
+  };
+
+  // Upload the generated image to Arweave
+  let arweaveData = null;
+  try {
+    arweaveData = await uploadBase64ToArweave(
+      imageData.base64Data,
+      imageData.mimeType,
+      `generated-image-${Date.now()}.png`
+    );
+  } catch (arweaveError) {
+    console.error("Error uploading to Arweave:", arweaveError);
+    // We'll continue and return the image even if Arweave upload fails
+  }
+  return arweaveData;
+};
+
+export default generateImage;

--- a/lib/arweave/uploadMetadataJson.ts
+++ b/lib/arweave/uploadMetadataJson.ts
@@ -4,8 +4,15 @@ import {
 } from "./uploadBase64ToArweave";
 
 interface CreateMetadataArgs {
-  image?: ArweaveUploadResult | null;
   name: string;
+  image?: ArweaveUploadResult | null;
+  animation_url?: ArweaveUploadResult | null;
+  description?: string;
+  external_url?: string;
+  content?: {
+    mime: string;
+    uri: string;
+  };
 }
 
 /**
@@ -13,11 +20,7 @@ interface CreateMetadataArgs {
  * @param args The metadata creation arguments
  * @returns The result from uploadBase64ToArweave
  */
-export async function uploadMetadataJson({ image, name }: CreateMetadataArgs) {
-  const metadata = {
-    image: image ? `ar://${image.id}` : "",
-    name,
-  };
+export async function uploadMetadataJson(metadata: CreateMetadataArgs) {
   const metadataBase64 = Buffer.from(JSON.stringify(metadata)).toString(
     "base64"
   );

--- a/lib/arweave/uploadMetadataJson.ts
+++ b/lib/arweave/uploadMetadataJson.ts
@@ -1,12 +1,9 @@
-import {
-  ArweaveUploadResult,
-  uploadBase64ToArweave,
-} from "./uploadBase64ToArweave";
+import { uploadBase64ToArweave } from "./uploadBase64ToArweave";
 
 interface CreateMetadataArgs {
   name: string;
-  image?: ArweaveUploadResult | null;
-  animation_url?: ArweaveUploadResult | null;
+  image?: string;
+  animation_url?: string;
   description?: string;
   external_url?: string;
   content?: {

--- a/lib/arweave/uploadMetadataJson.ts
+++ b/lib/arweave/uploadMetadataJson.ts
@@ -4,7 +4,7 @@ import {
 } from "./uploadBase64ToArweave";
 
 interface CreateMetadataArgs {
-  arweaveData?: ArweaveUploadResult | null;
+  image?: ArweaveUploadResult | null;
   name: string;
 }
 
@@ -13,12 +13,9 @@ interface CreateMetadataArgs {
  * @param args The metadata creation arguments
  * @returns The result from uploadBase64ToArweave
  */
-export async function uploadMetadataJson({
-  arweaveData,
-  name,
-}: CreateMetadataArgs) {
+export async function uploadMetadataJson({ image, name }: CreateMetadataArgs) {
   const metadata = {
-    image: arweaveData ? `ar://${arweaveData.id}` : "",
+    image: image ? `ar://${image.id}` : "",
     name,
   };
   const metadataBase64 = Buffer.from(JSON.stringify(metadata)).toString(

--- a/lib/imageGeneration.ts
+++ b/lib/imageGeneration.ts
@@ -1,11 +1,6 @@
-import { experimental_generateImage as generateImage } from "ai";
-import { openai } from "@ai-sdk/openai";
-import {
-  ArweaveUploadResult,
-  uploadBase64ToArweave,
-} from "@/lib/arweave/uploadBase64ToArweave";
+import generateImage from "./ai/generateImage";
+import { ArweaveUploadResult } from "@/lib/arweave/uploadBase64ToArweave";
 import createCollection from "@/app/api/in_process/createCollection";
-import { uploadMetadataJson } from "./arweave/uploadMetadataJson";
 
 export interface GeneratedImageResponse {
   image: {
@@ -34,58 +29,28 @@ export async function generateAndProcessImage(
   }
 
   // Generate the image using OpenAI
-  const response = await generateImage({
-    model: openai.image("gpt-image-1"),
-    prompt,
-    providerOptions: {
-      openai: { quality: "high" },
-    },
-  });
+  const image = await generateImage(prompt);
 
   // The base64Data isn't properly typed in the ai SDK, so we need to cast the response
   // @ts-expect-error The 'image' object from generateImage includes base64Data but it's not in the type
-  const base64Data: string = response.image.base64Data;
+  const base64Data: string = image.image.base64Data;
 
   const imageData = {
     base64Data,
-    mimeType: response.image.mimeType,
+    mimeType: image?.fileType || "image/png",
   };
-
-  // Upload the generated image to Arweave
-  let arweaveData = null;
-  try {
-    arweaveData = await uploadBase64ToArweave(
-      imageData.base64Data,
-      imageData.mimeType,
-      `generated-image-${Date.now()}.png`
-    );
-  } catch (arweaveError) {
-    console.error("Error uploading to Arweave:", arweaveError);
-    // We'll continue and return the image even if Arweave upload fails
-  }
-
-  // Upload metadata JSON to Arweave
-  let metadataArweave = null;
-  try {
-    metadataArweave = await uploadMetadataJson({
-      arweaveData,
-      name: prompt,
-    });
-  } catch (metadataError) {
-    console.error("Error uploading metadata to Arweave:", metadataError);
-  }
 
   // Create a collection on the blockchain using the metadata id
   const result = await createCollection({
     collectionName: prompt,
-    uri: metadataArweave ? `ar://${metadataArweave.id}` : "",
+    uri: image ? `ar://${image.id}` : "",
   });
   const transactionHash = result.transactionHash || null;
 
   // Return complete response
   return {
     image: imageData,
-    arweave: arweaveData,
+    arweave: image,
     smartAccount: result.smartAccount,
     transactionHash,
   };

--- a/lib/txtGeneration.ts
+++ b/lib/txtGeneration.ts
@@ -4,6 +4,7 @@ import {
 } from "@/lib/arweave/uploadBase64ToArweave";
 import createCollection from "@/app/api/in_process/createCollection";
 import { uploadMetadataJson } from "./arweave/uploadMetadataJson";
+import generateImage from "./ai/generateImage";
 
 export interface GeneratedTxtResponse {
   txt: {
@@ -31,19 +32,22 @@ export async function generateAndStoreTxtFile(
   const filename = `generated-text-${Date.now()}.txt`;
 
   // Upload the TXT file to Arweave
-  let arweaveData = null;
+  let txtFile = null;
   try {
-    arweaveData = await uploadBase64ToArweave(base64Data, mimeType, filename);
+    txtFile = await uploadBase64ToArweave(base64Data, mimeType, filename);
   } catch (arweaveError) {
     console.error("Error uploading TXT to Arweave:", arweaveError);
     // Continue and return the TXT even if Arweave upload fails
   }
 
+  const txtImage = await generateImage(contents);
+
   // Upload metadata JSON to Arweave
   let metadataArweave = null;
   try {
     metadataArweave = await uploadMetadataJson({
-      image: arweaveData,
+      image: txtImage,
+      animation_url: txtFile,
       name: contents,
     });
   } catch (metadataError) {
@@ -62,7 +66,7 @@ export async function generateAndStoreTxtFile(
       base64Data,
       mimeType,
     },
-    arweave: arweaveData,
+    arweave: txtFile,
     smartAccount: result.smartAccount,
     transactionHash,
   };

--- a/lib/txtGeneration.ts
+++ b/lib/txtGeneration.ts
@@ -4,7 +4,6 @@ import {
 } from "@/lib/arweave/uploadBase64ToArweave";
 import createCollection from "@/app/api/in_process/createCollection";
 import { uploadMetadataJson } from "./arweave/uploadMetadataJson";
-import generateImage from "./ai/generateImage";
 
 export interface GeneratedTxtResponse {
   txt: {
@@ -40,14 +39,19 @@ export async function generateAndStoreTxtFile(
     // Continue and return the TXT even if Arweave upload fails
   }
 
-  const txtImage = await generateImage(contents);
+  const image = "ar://EXwe2peizXKxjUMop6W-JPflC5sWyeQR1y0JiRDwUB0";
 
   // Upload metadata JSON to Arweave
   let metadataArweave = null;
   try {
     metadataArweave = await uploadMetadataJson({
-      image: txtImage,
-      animation_url: txtFile,
+      image,
+      animation_url: txtFile?.url,
+      content: {
+        mime: mimeType,
+        uri: txtFile?.url || "",
+      },
+      description: contents,
       name: contents,
     });
   } catch (metadataError) {

--- a/lib/txtGeneration.ts
+++ b/lib/txtGeneration.ts
@@ -43,7 +43,7 @@ export async function generateAndStoreTxtFile(
   let metadataArweave = null;
   try {
     metadataArweave = await uploadMetadataJson({
-      arweaveData,
+      image: arweaveData,
       name: contents,
     });
   } catch (metadataError) {


### PR DESCRIPTION
## Summary
- create `inProcessImplementationAbi` constant
- add helper `getSetupNewTokenCall` under `app/lib/in_process`
- use helper in `createCollection`

## Testing
- `pnpm exec next lint` *(fails: Command "next" not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for initializing a new token with custom parameters during contract creation.
  - Introduced AI-powered image generation with automatic storage and retrieval.
- **Chores**
  - Improved internal handling of contract setup actions for better extensibility.
- **Refactor**
  - Updated metadata upload process to support richer content fields and simplified input.
  - Streamlined image generation workflow by integrating a custom image generation and storage function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->