### PR TITLE
Refresh artists after creation

### DIFF
--- a/components/VercelChat/tools/CreateArtistToolResult.tsx
+++ b/components/VercelChat/tools/CreateArtistToolResult.tsx
@@ -22,11 +22,7 @@ export function CreateArtistToolResult({
   const { isProcessing, error: processingError } = useCreateArtistTool(result);
 
   useEffect(() => {
-    if (result.artistAccountId) {
-      (async () => {
-        await getArtists(result.artistAccountId);
-      })();
-    }
+    getArtists(result.artistAccountId);
   }, [result.artistAccountId, getArtists]);
 
   // If there's an error or no artist data, show error state

--- a/components/VercelChat/tools/CreateArtistToolResult.tsx
+++ b/components/VercelChat/tools/CreateArtistToolResult.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { CreateArtistResult } from "@/lib/tools/createArtist";
 import useCreateArtistTool from "@/hooks/useCreateArtistTool";
 import GenericSuccess from "./GenericSuccess";
+import { useArtistProvider } from "@/providers/ArtistProvider";
 
 /**
  * Props for the CreateArtistToolResult component
@@ -17,7 +18,16 @@ interface CreateArtistToolResultProps {
 export function CreateArtistToolResult({
   result,
 }: CreateArtistToolResultProps) {
+  const { getArtists } = useArtistProvider();
   const { isProcessing, error: processingError } = useCreateArtistTool(result);
+
+  useEffect(() => {
+    if (result.artistAccountId) {
+      (async () => {
+        await getArtists(result.artistAccountId);
+      })();
+    }
+  }, [result.artistAccountId, getArtists]);
 
   // If there's an error or no artist data, show error state
   if (!result.artist) {


### PR DESCRIPTION
## Summary
- remove string handling from `useInitialArtists` helper
- refresh artist list after creation using `getArtists`

## Testing
- `pnpm lint` *(fails: next not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Artist list now updates automatically after creating a new artist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->