### PR TITLE
Add Spotify artist albums tool

### DIFF
--- a/lib/tools/getMcpTools.ts
+++ b/lib/tools/getMcpTools.ts
@@ -10,6 +10,7 @@ import generateMermaidDiagram from "./generateMermaidDiagram";
 import createArtist from "./createArtist";
 import deleteArtist from "./deleteArtist";
 import getSpotifySearch from "./getSpotifySearch";
+import getSpotifyArtistAlbums from "./getSpotifyArtistAlbums";
 import updateAccountInfo from "./updateAccountInfo";
 import updateArtistSocialsTool from "./updateArtistSocials";
 import createTxtFile from "./createTxtFile";
@@ -36,6 +37,7 @@ export async function getMcpTools() {
     create_new_artist: createArtist,
     delete_artist: deleteArtist,
     get_spotify_search: getSpotifySearch,
+    get_spotify_artist_albums: getSpotifyArtistAlbums,
     update_account_info: updateAccountInfo,
     update_artist_socials: updateArtistSocialsTool,
     search_twitter: searchTwitter,

--- a/lib/tools/getSpotifyArtistAlbums.ts
+++ b/lib/tools/getSpotifyArtistAlbums.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import { tool } from "ai";
+
+// Types for the API response based on Recoup docs
+export interface SimplifiedArtist {
+  external_urls: { spotify: string };
+  href: string;
+  id: string;
+  name: string;
+  type: "artist";
+  uri: string;
+}
+
+export interface SimplifiedAlbum {
+  album_type: "album" | "single" | "compilation";
+  total_tracks: number;
+  available_markets: string[];
+  external_urls: { spotify: string };
+  href: string;
+  id: string;
+  images: { url: string; height: number; width: number }[];
+  name: string;
+  release_date: string;
+  release_date_precision: "year" | "month" | "day";
+  restrictions?: { reason: string };
+  type: "album";
+  uri: string;
+  artists: SimplifiedArtist[];
+  album_group?: "album" | "single" | "compilation" | "appears_on";
+}
+
+export interface ArtistAlbumsResponse {
+  href: string;
+  limit: number;
+  next: string | null;
+  offset: number;
+  previous: string | null;
+  total: number;
+  items: SimplifiedAlbum[];
+}
+
+// Zod schema for parameter validation
+const schema = z.object({
+  id: z.string().min(1, "Artist ID is required"),
+  include_groups: z
+    .string()
+    .optional()
+    .describe(
+      "Comma separated values of album types: album, single, appears_on, compilation"
+    ),
+  market: z
+    .string()
+    .length(2)
+    .optional()
+    .describe("ISO 3166-1 alpha-2 country code"),
+  limit: z.number().min(1).max(50).optional().default(20),
+  offset: z.number().min(0).optional().default(0),
+});
+
+const getSpotifyArtistAlbums = tool({
+  description:
+    "Retrieve Spotify catalog information about an artist's albums. You should call get_artist_socials or get_spotify_search first to obtain the artist ID before using this tool.",
+  parameters: schema,
+  execute: async ({ id, include_groups, market, limit = 20, offset = 0 }): Promise<ArtistAlbumsResponse> => {
+    const url = new URL("https://api.recoupable.com/api/spotify/artist/albums");
+    url.searchParams.append("id", id);
+    if (include_groups) url.searchParams.append("include_groups", include_groups);
+    if (market) url.searchParams.append("market", market);
+    if (limit) url.searchParams.append("limit", limit.toString());
+    if (offset) url.searchParams.append("offset", offset.toString());
+
+    try {
+      const response = await fetch(url.toString(), {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      if (!response.ok) {
+        throw new Error(`API request failed with status ${response.status}`);
+      }
+
+      return (await response.json()) as ArtistAlbumsResponse;
+    } catch (error) {
+      console.error("Error fetching Spotify artist albums:", error);
+      throw error instanceof Error
+        ? error
+        : new Error("Failed to fetch Spotify artist albums");
+    }
+  },
+});
+
+export default getSpotifyArtistAlbums;


### PR DESCRIPTION
## Summary
- add `getSpotifyArtistAlbums` tool for fetching albums by artist id
- expose new tool from `getMcpTools`

## Testing
- `pnpm lint` *(fails: next not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new tool to fetch Spotify artist albums, allowing users to retrieve album data for a specified artist, including filtering and pagination options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->