### PR TITLE
Add spotify deep research tool

### DIFF
--- a/lib/tools/getMcpTools.ts
+++ b/lib/tools/getMcpTools.ts
@@ -22,6 +22,7 @@ import getApifyScraper from "./getApifyScraper";
 import scrapeInstagramComments from "./scrapeInstagramComments";
 import artistDeepResearch from "./artistDeepResearch";
 import getVideoGameCampaignPlays from "./getVideoGameCampaignPlays";
+import getSpotifyDeepResearch from "./getSpotifyDeepResearch";
 
 export async function getMcpTools() {
   const tools = {
@@ -48,6 +49,7 @@ export async function getMcpTools() {
     get_apify_scraper: getApifyScraper,
     scrape_instagram_comments: scrapeInstagramComments,
     artist_deep_research: artistDeepResearch,
+    spotify_deep_research: getSpotifyDeepResearch,
     get_video_game_campaign_plays: getVideoGameCampaignPlays,
   };
 

--- a/lib/tools/getSpotifyDeepResearch.ts
+++ b/lib/tools/getSpotifyDeepResearch.ts
@@ -6,6 +6,7 @@ const TOOL_CHAIN_STEPS = [
   "get_artist_socials - get spotify account",
   "get_spotify_artist_top_tracks - top tracks for artist",
   "get_spotify_artist_albums - albums for artist",
+  "get_spotify_album - album from get_spotify_artist_albums. repeat this tool for each album.",
   "generate_txt_file - generate a txt file with the research generated",
 ];
 

--- a/lib/tools/getSpotifyDeepResearch.ts
+++ b/lib/tools/getSpotifyDeepResearch.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { tool } from "ai";
+import { getArtistSocials } from "../api/artist/getArtistSocials";
+
+const TOOL_CHAIN_STEPS = [
+  "get_artist_socials - get spotify account",
+  "get_spotify_artist_top_tracks - top tracks for artist",
+  "get_spotify_artist_albums - albums for artist",
+  "generate_txt_file - generate a txt file with the research generated",
+];
+
+const getSpotifyDeepResearch = tool({
+  description: `
+  Performs deep research on an artist using a Spotify ID.
+  Follows this tool loop:
+  <tool_loop>
+  ${TOOL_CHAIN_STEPS.join("\n")}
+  </tool_loop>
+  `,
+  parameters: z.object({
+    spotifyArtistId: z.string().describe("Spotify artist ID to research"),
+  }),
+  execute: async ({ spotifyArtistId }) => {
+    const data = await getArtistSocials(spotifyArtistId);
+    return {
+      artistSocials: data,
+      spotifyArtistId,
+      success: true,
+      nextSteps: TOOL_CHAIN_STEPS,
+    };
+  },
+});
+
+export default getSpotifyDeepResearch;

--- a/lib/tools/getSpotifyDeepResearch.ts
+++ b/lib/tools/getSpotifyDeepResearch.ts
@@ -32,13 +32,13 @@ const getSpotifyDeepResearch = tool({
   Plan thoroughly before every tool call and reflect on the outcome after each tool call.
   `,
   parameters: z.object({
-    spotifyArtistId: z.string().describe("Spotify artist ID to research"),
+    artist_account_id: z.string().describe("Artist account ID to research"),
   }),
-  execute: async ({ spotifyArtistId }) => {
-    const data = await getArtistSocials(spotifyArtistId);
+  execute: async ({ artist_account_id }) => {
+    const data = await getArtistSocials(artist_account_id);
     return {
       artistSocials: data,
-      spotifyArtistId,
+      artist_account_id,
       success: true,
       nextSteps: TOOL_CHAIN_STEPS,
     };

--- a/lib/tools/getSpotifyDeepResearch.ts
+++ b/lib/tools/getSpotifyDeepResearch.ts
@@ -7,7 +7,8 @@ const TOOL_CHAIN_STEPS = [
   "get_spotify_artist_top_tracks - top tracks for artist",
   "get_spotify_artist_albums - albums for artist",
   "get_spotify_album - album from get_spotify_artist_albums. repeat this tool for each album.",
-  "generate_txt_file - generate a txt file with the research generated",
+  "<other tools to get engagement info or other missing required items>",
+  "generate_txt_file - generate a txt file with the research generated.",
 ];
 
 const getSpotifyDeepResearch = tool({
@@ -17,6 +18,18 @@ const getSpotifyDeepResearch = tool({
   <tool_loop>
   ${TOOL_CHAIN_STEPS.join("\n")}
   </tool_loop>
+
+  required items in deep research document:
+  - popularity info
+  - engagement info
+  - tracklist
+  - collaborators
+  - album art
+  - album name
+
+  Keep going until the job is completely solved before ending your turn.
+  If you're unsure, use your tools, don't guess.
+  Plan thoroughly before every tool call and reflect on the outcome after each tool call.
   `,
   parameters: z.object({
     spotifyArtistId: z.string().describe("Spotify artist ID to research"),


### PR DESCRIPTION
## Summary
- add new `spotify_deep_research` tool
- integrate tool into MCP tools index

## Testing
- `pnpm lint` *(fails: `next` not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new tool for conducting in-depth research on Spotify artists, including retrieving their social media accounts and outlining further research steps. This feature is accessible by providing a Spotify artist ID.
	- Added integration of the new Spotify deep research tool within the existing tools collection for streamlined access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->