### PR TITLE
Add create knowledge base tool

### DIFF
--- a/lib/tools/artistDeepResearch.ts
+++ b/lib/tools/artistDeepResearch.ts
@@ -8,8 +8,7 @@ const TOOL_CHAIN_STEPS = [
   "update_artist_socials - link the discovered socials to the artist",
   "get_spotify_search - get the spotify search results for the artist across all search types (tracks, albums, playlists)",
   "perplexity_ask - loop over this tool until you have all the info required below",
-  "generate_txt_file - of the deep research",
-  "update_account_info - add the txt as a knowledge base for the artist",
+  "create_knowledge_base - generate a research txt file and attach it to the artist",
 ];
 
 const artistDeepResearch = tool({

--- a/lib/tools/createKnowledgeBase.ts
+++ b/lib/tools/createKnowledgeBase.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { tool } from "ai";
+
+const TOOL_CHAIN_STEPS = [
+  "generate_txt_file - of the deep research",
+  "update_account_info - add the txt as a knowledge base for the artist",
+];
+
+const createKnowledgeBase = tool({
+  description: `
+  Adds a knowledge base file to the active artist by generating a text file and appending it to the list of existing knowledge bases.
+  Follows this tool loop:
+  <tool_loop>
+  ${TOOL_CHAIN_STEPS.join("\n")}
+  </tool_loop>
+
+  Keep going until the job is completely solved before ending your turn.
+  If you're unsure, use your tools, don't guess.
+  Plan thoroughly before every tool call and reflect on the outcome after each tool call.
+  `,
+  parameters: z.object({
+    knowledgeBaseText: z.string().describe("Text to add to the knowledge base"),
+  }),
+  execute: async ({ knowledgeBaseText }) => {
+    return {
+      success: true,
+      knowledgeBaseText,
+      nextSteps: TOOL_CHAIN_STEPS,
+      message: "Follow the tool loop to create and store the knowledge base.",
+    };
+  },
+});
+
+export default createKnowledgeBase;

--- a/lib/tools/getMcpTools.ts
+++ b/lib/tools/getMcpTools.ts
@@ -24,6 +24,7 @@ import scrapeInstagramComments from "./scrapeInstagramComments";
 import artistDeepResearch from "./artistDeepResearch";
 import getVideoGameCampaignPlays from "./getVideoGameCampaignPlays";
 import getSpotifyDeepResearch from "./getSpotifyDeepResearch";
+import createKnowledgeBase from "./createKnowledgeBase";
 
 export async function getMcpTools() {
   const tools = {
@@ -52,6 +53,7 @@ export async function getMcpTools() {
     scrape_instagram_comments: scrapeInstagramComments,
     artist_deep_research: artistDeepResearch,
     spotify_deep_research: getSpotifyDeepResearch,
+    create_knowledge_base: createKnowledgeBase,
     get_video_game_campaign_plays: getVideoGameCampaignPlays,
   };
 

--- a/lib/tools/getSpotifyDeepResearch.ts
+++ b/lib/tools/getSpotifyDeepResearch.ts
@@ -8,7 +8,7 @@ const TOOL_CHAIN_STEPS = [
   "get_spotify_artist_albums - albums for artist",
   "get_spotify_album - album from get_spotify_artist_albums. repeat this tool for each album.",
   "<other tools to get engagement info or other missing required items>",
-  "generate_txt_file - generate a txt file with the research generated.",
+  "create_knowledge_base - generate a txt file with the research and attach it to the artist",
 ];
 
 const getSpotifyDeepResearch = tool({


### PR DESCRIPTION
## Summary
- create a `createKnowledgeBase` tool that guides generating a text file and adding it to the artist knowledge base
- wire the new tool into `getMcpTools`
- use `create_knowledge_base` in the artist and Spotify deep research tool loops

## Testing
- `pnpm lint` *(fails: `next` not found)*