### PR TITLE
Add social_posts saving for Apify webhook

### DIFF
--- a/lib/apify/handleApifyWebhook.ts
+++ b/lib/apify/handleApifyWebhook.ts
@@ -6,6 +6,7 @@ import apifyPayloadSchema from "@/lib/apify/apifyPayloadSchema";
 import { z } from "zod";
 import insertSocial from "@/lib/supabase/socials/insertSocial";
 import getSocialByProfileUrl from "@/lib/supabase/socials/getSocialByProfileUrl";
+import insertSocialPosts from "@/lib/supabase/socialPosts/insertSocialPosts";
 
 /**
  * Handles the Apify webhook payload: fetches dataset, saves posts, saves socials, and returns results.
@@ -38,7 +39,16 @@ export default async function handleApifyWebhook(
           followingCount: firstResult.followsCount,
         });
         const social = await getSocialByProfileUrl(firstResult.url);
-        if (social) supabaseSocials.push(social);
+        if (social) {
+          supabaseSocials.push(social);
+          if (supabasePosts.length) {
+            const socialPostRows = supabasePosts.map((post) => ({
+              post_id: post.id,
+              social_id: social.id,
+            }));
+            await insertSocialPosts(socialPostRows);
+          }
+        }
       }
     } catch (e) {
       console.error("Failed to handle Apify webhook:", e);

--- a/lib/supabase/socialPosts/insertSocialPosts.ts
+++ b/lib/supabase/socialPosts/insertSocialPosts.ts
@@ -1,0 +1,16 @@
+import supabase from "../serverClient";
+import type { TablesInsert } from "@/types/database.types";
+
+/**
+ * Creates records in the social_posts table.
+ * @param socialPosts - Array of rows to insert.
+ * @returns Supabase insert result
+ */
+export default async function insertSocialPosts(
+  socialPosts: TablesInsert<"social_posts">[],
+) {
+  const { data, error } = await supabase
+    .from("social_posts")
+    .insert(socialPosts);
+  return { data, error };
+}


### PR DESCRIPTION
## Summary
- support recording social posts from Apify webhook
- add `insertSocialPosts` helper for Supabase
- save social_posts entries when webhook posts are stored

## Testing
- `pnpm lint` *(fails: `next` not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Social posts are now automatically linked to their corresponding social entity, enhancing data organization and retrieval for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->